### PR TITLE
Add dry_run input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
   dialect:
     description: "SQL dialect used in the dbt project (e.g., 'snowflake', 'bigquery', 'redshift')"
     required: true
+  dry_run:
+    description: "If true, will compile and analyze changes but won't trigger the dbt Cloud job"
+    required: false
+    default: false
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/src/config.py
+++ b/src/config.py
@@ -22,6 +22,7 @@ class Config:
     dbt_cloud_job_id: str
     dialect: str
     dbt_cloud_environment_id: str = field(default=None)
+    dry_run: bool = field(default=False)
     dbtc_client: dbtCloudClient = field(
         init=False
     )  # This is set in post_init, so we'll keep it as a field
@@ -54,6 +55,9 @@ class Config:
         dialect = os.getenv("INPUT_DIALECT", None)
         if dialect is not None:
             env_vars["dialect"] = dialect
+
+        dry_run = os.getenv("INPUT_DRY_RUN", "false").lower() == "true"
+        env_vars["dry_run"] = dry_run
 
         missing_vars = []
         required_vars = [

--- a/src/interfaces/lineage.py
+++ b/src/interfaces/lineage.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING, List, Protocol, Set
+from typing import TYPE_CHECKING, Dict, List, Protocol, Set
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from src.models.node import Node
 
 
@@ -8,3 +8,5 @@ class LineageServiceProtocol(Protocol):
     def get_node_lineage(self, nodes: List["Node"]) -> Set[str]: ...
 
     def get_column_lineage(self, node_id: str, column_name: str) -> Set[str]: ...
+
+    def get_compiled_code(self, unique_ids: List[str]) -> Dict[str, Dict[str, str]]: ...

--- a/src/main.py
+++ b/src/main.py
@@ -30,5 +30,5 @@ def main():
         sys.exit(1)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/models/breaking_change.py
+++ b/src/models/breaking_change.py
@@ -86,7 +86,7 @@ class BreakingChange:
 
         # Get the CTE alias and column name from the original expression
         cte_alias = self._find_cte_alias(root, cte)
-        column_name = expr.output_name
+        column_name = expr.alias_or_name
 
         # Find all columns in the main SELECT that reference this CTE
         for column in find_all_in_scope(root, exp.Column):
@@ -97,8 +97,8 @@ class BreakingChange:
                     # Get the final output name (which may be an alias)
                     parent_alias = column.find_ancestor(exp.Alias)
                     if parent_alias:
-                        return parent_alias.output_name
-                    return column.output_name
+                        return parent_alias.alias_or_name
+                    return column.alias_or_name
 
         # If we couldn't find a reference, return the original name
         return column_name
@@ -121,7 +121,7 @@ class BreakingChange:
                 if self._in_cte(expr):
                     return self._find_parent_column_name(expr)
                 else:
-                    return expr.output_name
+                    return expr.alias_or_name
 
             elif expr.depth < 1:
                 return None

--- a/src/models/column_tracker.py
+++ b/src/models/column_tracker.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Set
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from src.models.node import Node
     from src.services.lineage_service import LineageService
 
@@ -65,7 +65,7 @@ class ColumnTracker:
         return impacted_ids
 
     @property
-    def impacted_ids(self) -> Set[str]:
+    def impacted_ids(self):
         """
         Get all node IDs impacted by tracked column changes.
 
@@ -73,4 +73,4 @@ class ColumnTracker:
             Set[str]: Set of all node IDs that are impacted by any tracked
                      column changes
         """
-        return self._impacted_ids
+        return self._impacted_ids.copy()

--- a/src/services/lineage_service.py
+++ b/src/services/lineage_service.py
@@ -10,7 +10,7 @@ from src.services.discovery_client import DiscoveryClient
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from src.models.node import Node
 
 

--- a/src/services/orchestrator.py
+++ b/src/services/orchestrator.py
@@ -114,12 +114,30 @@ class CiOrchestrator(OrchestratorProtocol):
         """
         Trigger a dbt Cloud job and check its status.
 
+        If dry_run is True, will only log what would happen instead of actually
+        triggering the job.
+
         Args:
             excluded_nodes: Optional list of node names to exclude from the build
 
         Returns:
-            bool: True if the job completed successfully, False otherwise
+            bool: True if the job completed successfully (or if dry_run), False otherwise
         """
+        if self.config.dry_run:
+            dry_run_message = (
+                "--------------- DRY RUN MODE ---------------\n"
+                "Dry run mode is enabled and a dbt Cloud job will not be triggered.\n"
+                "The total number of models that would've been excluded from the build "
+                f"are: {len(excluded_nodes or [])}"
+                "\n"
+                "Models that would've been excluded from the build are listed below:\n"
+                + "\n".join([f" - {node}" for node in sorted(excluded_nodes or [])])
+                + "\n"
+                "--------------------------------------------"
+            )
+            logger.info(dry_run_message)
+            return True
+
         run = trigger_job(self.config, excluded_nodes=excluded_nodes)
 
         try:

--- a/tests/models/test_column_tracker.py
+++ b/tests/models/test_column_tracker.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.models.column_tracker import ColumnTracker
+from src.models.node import Node
+
+
+@pytest.fixture
+def mock_node():
+    """Create a mock Node instance with column changes."""
+    node = MagicMock(spec=Node)
+    node.unique_id = "model.my_project.test_model"
+    node.column_changes = {"column1", "column2"}
+    return node
+
+
+def test_column_tracker_initialization(mock_lineage_service):
+    """Test ColumnTracker initialization."""
+    tracker = ColumnTracker(mock_lineage_service)
+    assert tracker._tracked_columns == set()
+    assert tracker._impacted_ids == set()
+    assert tracker._lineage_service == mock_lineage_service
+
+
+def test_track_node_columns_new_columns(mock_lineage_service, mock_node):
+    """Test tracking new columns in a node."""
+    # Setup mock lineage service to return some impacted nodes
+    mock_lineage_service.get_column_lineage.return_value = {
+        "model.my_project.downstream_model1",
+        "model.my_project.downstream_model2",
+    }
+
+    tracker = ColumnTracker(mock_lineage_service)
+    impacted_ids = tracker.track_node_columns(mock_node)
+
+    # Verify the results
+    expected_tracked_columns = {
+        "model.my_project.test_model.column1",
+        "model.my_project.test_model.column2",
+    }
+    expected_impacted_ids = {
+        "model.my_project.downstream_model1",
+        "model.my_project.downstream_model2",
+    }
+
+    assert tracker._tracked_columns == expected_tracked_columns
+    assert tracker._impacted_ids == expected_impacted_ids
+    assert impacted_ids == expected_impacted_ids
+
+    # Verify lineage service was called correctly
+    assert mock_lineage_service.get_column_lineage.call_count == 2
+    mock_lineage_service.get_column_lineage.assert_any_call(
+        "model.my_project.test_model", "column1"
+    )
+    mock_lineage_service.get_column_lineage.assert_any_call(
+        "model.my_project.test_model", "column2"
+    )
+
+
+def test_track_node_columns_already_tracked(mock_lineage_service, mock_node):
+    """Test tracking columns that have already been tracked."""
+    tracker = ColumnTracker(mock_lineage_service)
+
+    # Pre-populate tracked columns
+    tracker._tracked_columns.add("model.my_project.test_model.column1")
+
+    # First call to get_column_lineage returns some impacted nodes
+    mock_lineage_service.get_column_lineage.return_value = {
+        "model.my_project.downstream_model1"
+    }
+
+    impacted_ids = tracker.track_node_columns(mock_node)
+
+    # Verify the results
+    expected_tracked_columns = {
+        "model.my_project.test_model.column1",
+        "model.my_project.test_model.column2",
+    }
+    expected_impacted_ids = {"model.my_project.downstream_model1"}
+
+    assert tracker._tracked_columns == expected_tracked_columns
+    assert tracker._impacted_ids == expected_impacted_ids
+    assert impacted_ids == expected_impacted_ids
+
+    # Verify lineage service was called only once (for column2)
+    mock_lineage_service.get_column_lineage.assert_called_once_with(
+        "model.my_project.test_model", "column2"
+    )
+
+
+def test_impacted_ids_property(mock_lineage_service):
+    """Test the impacted_ids property."""
+    tracker = ColumnTracker(mock_lineage_service)
+
+    # Set some impacted IDs
+    expected_ids = {"model1", "model2"}
+    tracker._impacted_ids = expected_ids.copy()
+
+    assert tracker.impacted_ids == expected_ids
+    # Ensure we get a copy of the set, not the original
+    assert tracker.impacted_ids is not tracker._impacted_ids

--- a/tests/services/test_discovery_client.py
+++ b/tests/services/test_discovery_client.py
@@ -81,3 +81,91 @@ def test_get_node_lineage(discovery_client: DiscoveryClient) -> None:
     assert len(result) == 2
     assert "model.project.downstream1" in result
     assert "model.project.downstream2" in result
+
+
+def test_get_compiled_code(discovery_client: DiscoveryClient) -> None:
+    """Test compiled code retrieval."""
+    # Mock response data
+    mock_response = [
+        {
+            "node": {
+                "uniqueId": "model.project.test1",
+                "compiledCode": "SELECT * FROM table1",
+            }
+        },
+        {
+            "node": {
+                "uniqueId": "model.project.test2",
+                "compiledCode": "SELECT * FROM table2",
+            }
+        },
+    ]
+
+    # Mock the metadata query
+    discovery_client.config.dbtc_client.metadata.query = MagicMock(
+        return_value=mock_response
+    )
+
+    # Test the method
+    result = discovery_client.get_compiled_code(
+        environment_id="123", unique_ids=["model.project.test1", "model.project.test2"]
+    )
+
+    assert len(result) == 2
+    assert result["model.project.test1"]["source_code"] == "SELECT * FROM table1"
+    assert result["model.project.test2"]["source_code"] == "SELECT * FROM table2"
+
+
+def test_get_compiled_code_error_response(discovery_client: DiscoveryClient) -> None:
+    """Test compiled code retrieval with error response."""
+    # Mock error response
+    mock_response = [{"message": "API Error"}]
+
+    discovery_client.config.dbtc_client.metadata.query = MagicMock(
+        return_value=mock_response
+    )
+
+    result = discovery_client.get_compiled_code(
+        environment_id="123", unique_ids=["model.project.test1"]
+    )
+
+    assert result == {}
+
+
+def test_get_column_lineage_error(discovery_client: DiscoveryClient) -> None:
+    """Test column lineage retrieval with error."""
+    discovery_client.config.dbtc_client.metadata.query = MagicMock(
+        side_effect=Exception("API Error")
+    )
+
+    result = discovery_client.get_column_lineage(
+        environment_id="123", node_id="model.project.test", column_name="test_column"
+    )
+
+    assert result == []
+
+
+def test_get_node_lineage_error(discovery_client: DiscoveryClient) -> None:
+    """Test node lineage retrieval with error."""
+    discovery_client.config.dbtc_client.metadata.query = MagicMock(
+        side_effect=Exception("API Error")
+    )
+
+    result = discovery_client.get_node_lineage(
+        environment_id="123", node_names=["test_model"]
+    )
+
+    assert result == set()
+
+
+def test_get_compiled_code_error(discovery_client: DiscoveryClient) -> None:
+    """Test compiled code retrieval with error."""
+    discovery_client.config.dbtc_client.metadata.query = MagicMock(
+        side_effect=Exception("API Error")
+    )
+
+    result = discovery_client.get_compiled_code(
+        environment_id="123", unique_ids=["model.project.test1"]
+    )
+
+    assert result == {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 import pytest
@@ -116,3 +117,27 @@ def test_set_deferring_environment_id_missing_data(mock_config):
             "An error occurred retrieving your job's deferring environment ID"
             in str(exc_info.value)
         )
+
+
+def test_config_dry_run(mock_config):
+    # Default value from mock_config fixture should be False
+    assert mock_config.dry_run is False
+
+    # Test creating config with dry_run=True from environment
+    os.environ.update(
+        {
+            "INPUT_DBT_CLOUD_HOST": mock_config.dbt_cloud_host,
+            "INPUT_DBT_CLOUD_SERVICE_TOKEN": mock_config.dbt_cloud_service_token,
+            "INPUT_DBT_CLOUD_PROJECT_ID": mock_config.dbt_cloud_project_id,
+            "INPUT_DBT_CLOUD_PROJECT_NAME": mock_config.dbt_cloud_project_name,
+            "INPUT_DBT_CLOUD_TOKEN_NAME": mock_config.dbt_cloud_token_name,
+            "INPUT_DBT_CLOUD_TOKEN_VALUE": mock_config.dbt_cloud_token_value,
+            "INPUT_DBT_CLOUD_ACCOUNT_ID": mock_config.dbt_cloud_account_id,
+            "INPUT_DBT_CLOUD_JOB_ID": mock_config.dbt_cloud_job_id,
+            "INPUT_DIALECT": mock_config.dialect,
+            "INPUT_DRY_RUN": "true",
+        }
+    )
+
+    config_with_dry_run = Config.from_env()
+    assert config_with_dry_run.dry_run is True


### PR DESCRIPTION
The `dry_run` input will allow you to understand what would've been excluded without actually triggering a dbt Cloud CI job.  Think of it as a way to test-drive this action before putting it into production