### PR TITLE
Respect current job commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,10 @@ This results in faster CI runs and more efficient use of warehouse resources.
 |-------|-------------|----------|---------|
 | `dbt_cloud_account_id` | dbt Cloud Account ID | Yes | - |
 | `dbt_cloud_job_id` | dbt Cloud CI Job ID for the current project | Yes | - |
-| `dbt_cloud_project_id` | dbt Cloud Project ID | Yes | - |
-| `dbt_cloud_project_name` | dbt Cloud Project Name | Yes | - |
 | `dbt_cloud_service_token` | dbt Cloud Service Token | Yes | - |
 | `dbt_cloud_token_name` | Name of the personal API Key created in dbt Cloud | Yes | - |
 | `dbt_cloud_token_value` | dbt Cloud Personal API Key for use with the dbt Cloud CLI | Yes | - |
 | `dialect` | SQL dialect of your warehouse (e.g., 'snowflake') | Yes | - |
-| `dbt_cloud_environment_id` | dbt Cloud Environment ID for job deferral | No | Inferred from job |
 | `dbt_cloud_host` | dbt Cloud host | No | cloud.getdbt.com |
 | `dry_run` | When true, analyzes changes but doesn't trigger dbt Cloud job | No | false |
 | `github_token` | GitHub token for API authentication | No | ${{ github.token }} |
@@ -79,16 +76,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run Column-Aware dbt Cloud CI
-      uses: dpguthrie/dbt-cloud-column-aware-ci@0.4.1
+      uses: dpguthrie/dbt-cloud-column-aware-ci@0.4.2
       with:
         dbt_cloud_service_token: ${{ secrets.DBT_CLOUD_SERVICE_TOKEN }}
         dbt_cloud_token_name: 'github-actions'
         dbt_cloud_token_value: ${{ secrets.DBT_CLOUD_TOKEN_VALUE }}
         dbt_cloud_account_id: '12345'
-        dbt_cloud_project_id: '67890'
-        dbt_cloud_project_name: 'my-dbt-project'
         dbt_cloud_job_id: '98765'
-        dbt_cloud_environment_id: '238221'
         dialect: 'snowflake'
         log_level: 'DEBUG' # optional
 ```

--- a/action.yml
+++ b/action.yml
@@ -17,12 +17,6 @@ inputs:
   dbt_cloud_account_id:
     description: dbt Cloud Account ID
     required: true
-  dbt_cloud_project_id:
-    description: dbt Cloud Project ID
-    required: true
-  dbt_cloud_project_name:
-    description: dbt Cloud Project Name
-    required: true
   dbt_cloud_job_id:
     description: dbt Cloud CI Job ID for the current project
     required: true
@@ -30,16 +24,13 @@ inputs:
     description: dbt Cloud host
     required: false
     default: "cloud.getdbt.com"
-  dbt_cloud_environment_id:
-    description: dbt Cloud Environment ID (this is the environment that the CI job defers to).  If not given, it will be inferred from the CI job.
-    required: false
+  dialect:
+    description: "SQL dialect used in the dbt project (e.g., 'snowflake', 'bigquery', 'redshift')"
+    required: true
   log_level:
     description: "Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)"
     required: false
     default: "INFO"
-  dialect:
-    description: "SQL dialect used in the dbt project (e.g., 'snowflake', 'bigquery', 'redshift')"
-    required: true
   dry_run:
     description: "If true, will compile and analyze changes but won't trigger the dbt Cloud job"
     required: false

--- a/src/config.py
+++ b/src/config.py
@@ -93,7 +93,7 @@ class Config:
             )
         except Exception as e:
             raise Exception(
-                "An error occurred making a request to dbt Cloud." f"See error: {e}"
+                f"An error occurred making a request to dbt Cloud. See error: {e}"
             )
         try:
             job_data = ci_job["data"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,4 @@
-import os
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -11,10 +10,8 @@ def test_config_initialization(mock_config):
     assert mock_config.dbt_cloud_account_id == "43786"
     assert mock_config.dbt_cloud_job_id == "567183"
     assert mock_config.dbt_cloud_host == "cloud.getdbt.com"
-    assert mock_config.dbt_cloud_project_id == "270542"
-    assert mock_config.dbt_cloud_project_name == "Main"
     assert mock_config.dbt_cloud_token_name == "cloud-cli-6d65"
-    assert mock_config.dbt_cloud_environment_id == "218762"
+    assert mock_config.dbt_cloud_environment_id == 218762
 
 
 def test_config_from_env():
@@ -22,8 +19,6 @@ def test_config_from_env():
     env_vars = {
         "INPUT_DBT_CLOUD_HOST": "cloud.getdbt.com",
         "INPUT_DBT_CLOUD_SERVICE_TOKEN": "test_token",
-        "INPUT_DBT_CLOUD_PROJECT_ID": "270542",
-        "INPUT_DBT_CLOUD_PROJECT_NAME": "Main",
         "INPUT_DBT_CLOUD_TOKEN_NAME": "cloud-cli-6d65",
         "INPUT_DBT_CLOUD_TOKEN_VALUE": "test_token_value",
         "INPUT_DBT_CLOUD_ACCOUNT_ID": "43786",
@@ -33,43 +28,13 @@ def test_config_from_env():
 
     with (
         patch.dict("os.environ", env_vars, clear=True),
-        patch("src.config.Config._set_deferring_environment_id") as mock_set_env,
+        patch("src.config.Config._set_fields_from_dbtc_client") as mock_set_env,
     ):
         config = Config.from_env()
 
         assert config.dbt_cloud_host == "cloud.getdbt.com"
         assert config.dbt_cloud_service_token == "test_token"
-        assert config.dbt_cloud_project_id == "270542"
-        assert config.dbt_cloud_account_id == "43786"
         mock_set_env.assert_called_once()
-
-
-def test_config_from_env_with_env_id():
-    """Test Config creation from environment variables."""
-    env_vars = {
-        "INPUT_DBT_CLOUD_HOST": "cloud.getdbt.com",
-        "INPUT_DBT_CLOUD_SERVICE_TOKEN": "test_token",
-        "INPUT_DBT_CLOUD_PROJECT_ID": "270542",
-        "INPUT_DBT_CLOUD_PROJECT_NAME": "Main",
-        "INPUT_DBT_CLOUD_TOKEN_NAME": "cloud-cli-6d65",
-        "INPUT_DBT_CLOUD_TOKEN_VALUE": "test_token_value",
-        "INPUT_DBT_CLOUD_ACCOUNT_ID": "43786",
-        "INPUT_DBT_CLOUD_JOB_ID": "567183",
-        "INPUT_DBT_CLOUD_ENVIRONMENT_ID": "218762",
-        "INPUT_DIALECT": "snowflake",
-    }
-
-    with (
-        patch.dict("os.environ", env_vars, clear=True),
-        patch("src.config.Config._set_deferring_environment_id") as mock_set_env,
-    ):
-        config = Config.from_env()
-
-        assert config.dbt_cloud_host == "cloud.getdbt.com"
-        assert config.dbt_cloud_service_token == "test_token"
-        assert config.dbt_cloud_project_id == "270542"
-        assert config.dbt_cloud_account_id == "43786"
-        mock_set_env.assert_not_called()
 
 
 def test_config_missing_env_vars():
@@ -81,29 +46,7 @@ def test_config_missing_env_vars():
         assert "Missing required environment variables:" in str(exc_info.value)
 
 
-def test_set_deferring_environment_id(mock_config):
-    """Test setting deferring environment ID from dbt Cloud API."""
-    mock_response = {"data": {"deferring_environment_id": "218762"}}
-
-    with patch.object(
-        mock_config.dbtc_client.cloud, "get_job", return_value=mock_response
-    ):
-        mock_config._set_deferring_environment_id()
-        assert mock_config.dbt_cloud_environment_id == "218762"
-
-
-def test_set_deferring_environment_id_api_error(mock_config):
-    """Test handling of API error when setting deferring environment ID."""
-    with patch.object(
-        mock_config.dbtc_client.cloud, "get_job", side_effect=Exception("API Error")
-    ):
-        with pytest.raises(Exception) as exc_info:
-            mock_config._set_deferring_environment_id()
-
-        assert "An error occurred making a request to dbt Cloud" in str(exc_info.value)
-
-
-def test_set_deferring_environment_id_missing_data(mock_config):
+def test_set_fields_from_dbtc_client_missing_data(mock_config):
     """Test handling of missing data in API response."""
     mock_response = {"data": {}}  # Missing deferring_environment_id
 
@@ -111,33 +54,80 @@ def test_set_deferring_environment_id_missing_data(mock_config):
         mock_config.dbtc_client.cloud, "get_job", return_value=mock_response
     ):
         with pytest.raises(Exception) as exc_info:
-            mock_config._set_deferring_environment_id()
+            mock_config._set_fields_from_dbtc_client()
 
-        assert (
-            "An error occurred retrieving your job's deferring environment ID"
-            in str(exc_info.value)
-        )
+        assert "An error occurred retrieving your job's data" in str(exc_info.value)
 
 
 def test_config_dry_run(mock_config):
     # Default value from mock_config fixture should be False
     assert mock_config.dry_run is False
 
-    # Test creating config with dry_run=True from environment
-    os.environ.update(
-        {
-            "INPUT_DBT_CLOUD_HOST": mock_config.dbt_cloud_host,
-            "INPUT_DBT_CLOUD_SERVICE_TOKEN": mock_config.dbt_cloud_service_token,
-            "INPUT_DBT_CLOUD_PROJECT_ID": mock_config.dbt_cloud_project_id,
-            "INPUT_DBT_CLOUD_PROJECT_NAME": mock_config.dbt_cloud_project_name,
-            "INPUT_DBT_CLOUD_TOKEN_NAME": mock_config.dbt_cloud_token_name,
-            "INPUT_DBT_CLOUD_TOKEN_VALUE": mock_config.dbt_cloud_token_value,
-            "INPUT_DBT_CLOUD_ACCOUNT_ID": mock_config.dbt_cloud_account_id,
-            "INPUT_DBT_CLOUD_JOB_ID": mock_config.dbt_cloud_job_id,
-            "INPUT_DIALECT": mock_config.dialect,
-            "INPUT_DRY_RUN": "true",
-        }
-    )
+    # Test creating config with dry_run=True
+    env_vars = {
+        "INPUT_DBT_CLOUD_HOST": mock_config.dbt_cloud_host,
+        "INPUT_DBT_CLOUD_ACCOUNT_ID": mock_config.dbt_cloud_account_id,
+        "INPUT_DBT_CLOUD_SERVICE_TOKEN": mock_config.dbt_cloud_service_token,
+        "INPUT_DBT_CLOUD_TOKEN_NAME": mock_config.dbt_cloud_token_name,
+        "INPUT_DBT_CLOUD_TOKEN_VALUE": mock_config.dbt_cloud_token_value,
+        "INPUT_DBT_CLOUD_JOB_ID": mock_config.dbt_cloud_job_id,
+        "INPUT_DIALECT": mock_config.dialect,
+        "INPUT_DRY_RUN": "true",
+    }
 
-    config_with_dry_run = Config.from_env()
-    assert config_with_dry_run.dry_run is True
+    with (
+        patch.dict("os.environ", env_vars, clear=True),
+        patch("src.config.Config._set_fields_from_dbtc_client"),
+    ):
+        config_with_dry_run = Config.from_env()
+        assert config_with_dry_run.dry_run is True
+
+
+def test_set_fields_from_dbtc_client_success(mock_config):
+    # Mock response from dbt Cloud API
+    mock_response = {
+        "data": {
+            "deferring_environment_id": 218762,
+            "project": {"id": 270542, "name": "Main"},
+            "execute_steps": ["dbt build -s state:modified+"],
+        }
+    }
+
+    # Properly mock the get_job method using patch
+    with patch.object(
+        mock_config.dbtc_client.cloud, "get_job", return_value=mock_response
+    ):
+        mock_config._set_fields_from_dbtc_client()
+
+        # Assert fields were set correctly from the mock response
+        assert mock_config.dbt_cloud_environment_id == 218762
+        assert mock_config.dbt_cloud_project_id == 270542
+        assert mock_config.dbt_cloud_project_name == "Main"
+        assert mock_config.execute_steps == ["dbt build -s state:modified+"]
+
+
+def test_set_fields_from_dbtc_client_api_error(mock_config):
+    # Mock API call to raise an exception
+    mock_config.dbtc_client.cloud.get_job = Mock(side_effect=Exception("API Error"))
+
+    with pytest.raises(Exception) as exc_info:
+        mock_config._set_fields_from_dbtc_client()
+
+    assert "An error occurred making a request to dbt Cloud" in str(exc_info.value)
+
+
+def test_set_fields_from_dbtc_client_invalid_response(mock_config):
+    # Mock response with missing data
+    mock_response = {
+        "data": {
+            # Missing required fields
+        }
+    }
+
+    with patch.object(
+        mock_config.dbtc_client.cloud, "get_job", return_value=mock_response
+    ):
+        with pytest.raises(Exception) as exc_info:
+            mock_config._set_fields_from_dbtc_client()
+
+    assert "An error occurred retrieving your job's data" in str(exc_info.value)

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ dev = [
 
 [[package]]
 name = "dbtc"
-version = "0.11.5"
+version = "0.11.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pandas" },
@@ -246,9 +246,9 @@ dependencies = [
     { name = "requests" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/37/73f23ce1ebdc52dd6047a472b8e2430449b8fc6526e6714ca15d634f5f04/dbtc-0.11.5.tar.gz", hash = "sha256:cd132a1593f9d089d5b407cc08cb3794d8bdb37da49999d9805cb2d7ceeebb32", size = 164411 }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/02/d4340b57fe5799df5dc7408547d5665681a934e7760d77d4a838038e3025/dbtc-0.11.6.tar.gz", hash = "sha256:dd36d50209fe4ca87df8ae36c4d6d045fdc13f2506bc5cd1bd4548ce007d3c50", size = 164697 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/54/a2c22b5cf7048f2179609c8bf80627b7d264a4df3ee703d1f968f81cf558/dbtc-0.11.5-py3-none-any.whl", hash = "sha256:e5942ec8fb336f419d66ffcb17f8b894bc6d5e54e6b7c3e327dbacee5cfcfa98", size = 35260 },
+    { url = "https://files.pythonhosted.org/packages/41/9f/5e689b4ee11b585a15208f2664b9c6dc3c4d8fd2530bb18cdbae724d4cc0/dbtc-0.11.6-py3-none-any.whl", hash = "sha256:11be75dcc4d359176b779da3b4c22d7e2ec5620ffc63665340450a8785aaa983", size = 35285 },
 ]
 
 [[package]]
@@ -280,11 +280,11 @@ wheels = [
 
 [[package]]
 name = "identify"
-version = "2.6.3"
+version = "2.6.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/5f/05f0d167be94585d502b4adf8c7af31f1dc0b1c7e14f9938a88fdbbcf4a7/identify-2.6.3.tar.gz", hash = "sha256:62f5dae9b5fef52c84cc188514e9ea4f3f636b1d8799ab5ebc475471f9e47a02", size = 99179 }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/92/69934b9ef3c31ca2470980423fda3d00f0460ddefdf30a67adf7f17e2e00/identify-2.6.5.tar.gz", hash = "sha256:c10b33f250e5bba374fae86fb57f3adcebf1161bce7cdf92031915fd480c13bc", size = 99213 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/f5/09644a3ad803fae9eca8efa17e1f2aef380c7f0b02f7ec4e8d446e51d64a/identify-2.6.3-py2.py3-none-any.whl", hash = "sha256:9edba65473324c2ea9684b1f944fe3191db3345e50b6d04571d10ed164f8d7bd", size = 99049 },
+    { url = "https://files.pythonhosted.org/packages/ec/fa/dce098f4cdf7621aa8f7b4f919ce545891f489482f0bfa5102f3eca8608b/identify-2.6.5-py2.py3-none-any.whl", hash = "sha256:14181a47091eb75b337af4c23078c9d09225cd4c48929f521f3bf16b09d02566", size = 99078 },
 ]
 
 [[package]]
@@ -510,16 +510,16 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.4"
+version = "2.10.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/7e/fb60e6fee04d0ef8f15e4e01ff187a196fa976eb0f0ab524af4599e5754c/pydantic-2.10.4.tar.gz", hash = "sha256:82f12e9723da6de4fe2ba888b5971157b3be7ad914267dea8f05f82b28254f06", size = 762094 }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/c7/ca334c2ef6f2e046b1144fe4bb2a5da8a4c574e7f2ebf7e16b34a6a2fa92/pydantic-2.10.5.tar.gz", hash = "sha256:278b38dbbaec562011d659ee05f63346951b3a248a6f3642e1bc68894ea2b4ff", size = 761287 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/26/3e1bbe954fde7ee22a6e7d31582c642aad9e84ffe4b5fb61e63b87cd326f/pydantic-2.10.4-py3-none-any.whl", hash = "sha256:597e135ea68be3a37552fb524bc7d0d66dcf93d395acd93a00682f1efcb8ee3d", size = 431765 },
+    { url = "https://files.pythonhosted.org/packages/58/26/82663c79010b28eddf29dcdd0ea723439535fa917fce5905885c0e9ba562/pydantic-2.10.5-py3-none-any.whl", hash = "sha256:4dd4e322dbe55472cb7ca7e73f4b63574eecccf2835ffa2af9021ce113c83c53", size = 431426 },
 ]
 
 [[package]]
@@ -621,11 +621,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.18.0"
+version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
 ]
 
 [[package]]
@@ -763,27 +763,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.8.4"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/37/9c02181ef38d55b77d97c68b78e705fd14c0de0e5d085202bb2b52ce5be9/ruff-0.8.4.tar.gz", hash = "sha256:0d5f89f254836799af1615798caa5f80b7f935d7a670fad66c5007928e57ace8", size = 3402103 }
+sdist = { url = "https://files.pythonhosted.org/packages/75/48/385f276f41e89623a5ea8e4eb9c619a44fdfc2a64849916b3584eca6cb9f/ruff-0.9.0.tar.gz", hash = "sha256:143f68fa5560ecf10fc49878b73cee3eab98b777fcf43b0e62d43d42f5ef9d8b", size = 3489167 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/67/f480bf2f2723b2e49af38ed2be75ccdb2798fca7d56279b585c8f553aaab/ruff-0.8.4-py3-none-linux_armv6l.whl", hash = "sha256:58072f0c06080276804c6a4e21a9045a706584a958e644353603d36ca1eb8a60", size = 10546415 },
-    { url = "https://files.pythonhosted.org/packages/eb/7a/5aba20312c73f1ce61814e520d1920edf68ca3b9c507bd84d8546a8ecaa8/ruff-0.8.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ffb60904651c00a1e0b8df594591770018a0f04587f7deeb3838344fe3adabac", size = 10346113 },
-    { url = "https://files.pythonhosted.org/packages/76/f4/c41de22b3728486f0aa95383a44c42657b2db4062f3234ca36fc8cf52d8b/ruff-0.8.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ddf5d654ac0d44389f6bf05cee4caeefc3132a64b58ea46738111d687352296", size = 9943564 },
-    { url = "https://files.pythonhosted.org/packages/0e/f0/afa0d2191af495ac82d4cbbfd7a94e3df6f62a04ca412033e073b871fc6d/ruff-0.8.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e248b1f0fa2749edd3350a2a342b67b43a2627434c059a063418e3d375cfe643", size = 10805522 },
-    { url = "https://files.pythonhosted.org/packages/12/57/5d1e9a0fd0c228e663894e8e3a8e7063e5ee90f8e8e60cf2085f362bfa1a/ruff-0.8.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf197b98ed86e417412ee3b6c893f44c8864f816451441483253d5ff22c0e81e", size = 10306763 },
-    { url = "https://files.pythonhosted.org/packages/04/df/f069fdb02e408be8aac6853583572a2873f87f866fe8515de65873caf6b8/ruff-0.8.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c41319b85faa3aadd4d30cb1cffdd9ac6b89704ff79f7664b853785b48eccdf3", size = 11359574 },
-    { url = "https://files.pythonhosted.org/packages/d3/04/37c27494cd02e4a8315680debfc6dfabcb97e597c07cce0044db1f9dfbe2/ruff-0.8.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:9f8402b7c4f96463f135e936d9ab77b65711fcd5d72e5d67597b543bbb43cf3f", size = 12094851 },
-    { url = "https://files.pythonhosted.org/packages/81/b1/c5d7fb68506cab9832d208d03ea4668da9a9887a4a392f4f328b1bf734ad/ruff-0.8.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e4e56b3baa9c23d324ead112a4fdf20db9a3f8f29eeabff1355114dd96014604", size = 11655539 },
-    { url = "https://files.pythonhosted.org/packages/ef/38/8f8f2c8898dc8a7a49bc340cf6f00226917f0f5cb489e37075bcb2ce3671/ruff-0.8.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:736272574e97157f7edbbb43b1d046125fce9e7d8d583d5d65d0c9bf2c15addf", size = 12912805 },
-    { url = "https://files.pythonhosted.org/packages/06/dd/fa6660c279f4eb320788876d0cff4ea18d9af7d9ed7216d7bd66877468d0/ruff-0.8.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5fe710ab6061592521f902fca7ebcb9fabd27bc7c57c764298b1c1f15fff720", size = 11205976 },
-    { url = "https://files.pythonhosted.org/packages/a8/d7/de94cc89833b5de455750686c17c9e10f4e1ab7ccdc5521b8fe911d1477e/ruff-0.8.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:13e9ec6d6b55f6da412d59953d65d66e760d583dd3c1c72bf1f26435b5bfdbae", size = 10792039 },
-    { url = "https://files.pythonhosted.org/packages/6d/15/3e4906559248bdbb74854af684314608297a05b996062c9d72e0ef7c7097/ruff-0.8.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:97d9aefef725348ad77d6db98b726cfdb075a40b936c7984088804dfd38268a7", size = 10400088 },
-    { url = "https://files.pythonhosted.org/packages/a2/21/9ed4c0e8133cb4a87a18d470f534ad1a8a66d7bec493bcb8bda2d1a5d5be/ruff-0.8.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ab78e33325a6f5374e04c2ab924a3367d69a0da36f8c9cb6b894a62017506111", size = 10900814 },
-    { url = "https://files.pythonhosted.org/packages/0d/5d/122a65a18955bd9da2616b69bc839351f8baf23b2805b543aa2f0aed72b5/ruff-0.8.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8ef06f66f4a05c3ddbc9121a8b0cecccd92c5bf3dd43b5472ffe40b8ca10f0f8", size = 11268828 },
-    { url = "https://files.pythonhosted.org/packages/43/a9/1676ee9106995381e3d34bccac5bb28df70194167337ed4854c20f27c7ba/ruff-0.8.4-py3-none-win32.whl", hash = "sha256:552fb6d861320958ca5e15f28b20a3d071aa83b93caee33a87b471f99a6c0835", size = 8805621 },
-    { url = "https://files.pythonhosted.org/packages/10/98/ed6b56a30ee76771c193ff7ceeaf1d2acc98d33a1a27b8479cbdb5c17a23/ruff-0.8.4-py3-none-win_amd64.whl", hash = "sha256:f21a1143776f8656d7f364bd264a9d60f01b7f52243fbe90e7670c0dfe0cf65d", size = 9660086 },
-    { url = "https://files.pythonhosted.org/packages/13/9f/026e18ca7d7766783d779dae5e9c656746c6ede36ef73c6d934aaf4a6dec/ruff-0.8.4-py3-none-win_arm64.whl", hash = "sha256:9183dd615d8df50defa8b1d9a074053891ba39025cf5ae88e8bcb52edcc4bf08", size = 9074500 },
+    { url = "https://files.pythonhosted.org/packages/e9/01/e0885e5519212efc7ab9d868bc39cb9781931c4c6f9b17becafa81193ec4/ruff-0.9.0-py3-none-linux_armv6l.whl", hash = "sha256:949b3513f931741e006cf267bf89611edff04e1f012013424022add3ce78f319", size = 10647069 },
+    { url = "https://files.pythonhosted.org/packages/dd/69/510a9a5781dcf84c2ad513c2003936fefc802f39c745d5f2355d77fa45fd/ruff-0.9.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:99fbcb8c7fe94ae1e462ab2a1ef17cb20b25fb6438b9f198b1bcf5207a0a7916", size = 10401936 },
+    { url = "https://files.pythonhosted.org/packages/07/9f/37fb86bfdf28c4cbfe94cbcc01fb9ab0cb8128548f243f34d5298b212562/ruff-0.9.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0b022afd8eb0fcfce1e0adec84322abf4d6ce3cd285b3b99c4f17aae7decf749", size = 10010347 },
+    { url = "https://files.pythonhosted.org/packages/30/0d/b95121f53c7f7bfb7ba427a35d25f983ed3b476620c5cd69f45caa5b294e/ruff-0.9.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:336567ce92c9ca8ec62780d07b5fa11fbc881dc7bb40958f93a7d621e7ab4589", size = 10882152 },
+    { url = "https://files.pythonhosted.org/packages/d4/0b/a955cb6b19eb900c4c594707ab72132ce2d5cd8b5565137fb8fed21b8f08/ruff-0.9.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d338336c44bda602dc8e8766836ac0441e5b0dfeac3af1bd311a97ebaf087a75", size = 10405502 },
+    { url = "https://files.pythonhosted.org/packages/1e/fa/9a6c70af74f20edd2519b89eb3322f4bfa399315cf306383443700f2d6b6/ruff-0.9.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d9b3ececf523d733e90b540e7afcc0494189e8999847f8855747acd5a9a8c45f", size = 11465069 },
+    { url = "https://files.pythonhosted.org/packages/ee/8b/7effac8915470da496be009fe861060baff2692f92801976b2c01cdc8c54/ruff-0.9.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:a11c0872a31232e473e2e0e2107f3d294dbadd2f83fb281c3eb1c22a24866924", size = 12176850 },
+    { url = "https://files.pythonhosted.org/packages/bd/ed/626179786889eca47b1e821c1582622ac0c1c8f01d60ac974f8b96867a57/ruff-0.9.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b5fd06220c17a9cc0dc7fc6552f2ac4db74e8e8bff9c401d160ac59d00566f54", size = 11700963 },
+    { url = "https://files.pythonhosted.org/packages/75/79/094c34ddec47fd3c61a0bc5e83ca164344c592949cff91f05961fd40922e/ruff-0.9.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0457e775c74bf3976243f910805242b7dcd389e1d440deccbd1194ca17a5728c", size = 13096560 },
+    { url = "https://files.pythonhosted.org/packages/e7/23/ec85dca0dcb329835197401734501bfa1d39e72343df64628c67b72bcbf5/ruff-0.9.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05415599bbcb318f730ea1b46a39e4fbf71f6a63fdbfa1dda92efb55f19d7ecf", size = 11278658 },
+    { url = "https://files.pythonhosted.org/packages/6c/17/1b3ea5f06578ea1daa08ac35f9de099d1827eea6e116a8cabbf11235c925/ruff-0.9.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fbf9864b009e43cfc1c8bed1a6a4c529156913105780af4141ca4342148517f5", size = 10879847 },
+    { url = "https://files.pythonhosted.org/packages/a6/e5/00bc97d6f419da03c0d898e95cca77311494e7274dc7cc17d94976e32e52/ruff-0.9.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:37b3da222b12e2bb2ce628e02586ab4846b1ed7f31f42a5a0683b213453b2d49", size = 10494220 },
+    { url = "https://files.pythonhosted.org/packages/cc/70/d0a23d94f3e40b7ffac0e5506f33bb504672569173781a6c7cab0db6a4ba/ruff-0.9.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:733c0fcf2eb0c90055100b4ed1af9c9d87305b901a8feb6a0451fa53ed88199d", size = 11004182 },
+    { url = "https://files.pythonhosted.org/packages/20/8e/367cf8e401890f823d0e4eb33635d0113719d5660b6522b7295376dd95fd/ruff-0.9.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8221a454bfe5ccdf8017512fd6bb60e6ec30f9ea252b8a80e5b73619f6c3cefd", size = 11345761 },
+    { url = "https://files.pythonhosted.org/packages/fe/08/4b54e02da73060ebc29368ab15868613f7d2496bde3b01d284d5423646bc/ruff-0.9.0-py3-none-win32.whl", hash = "sha256:d345f2178afd192c7991ddee59155c58145e12ad81310b509bd2e25c5b0247b3", size = 8807005 },
+    { url = "https://files.pythonhosted.org/packages/a1/a7/0b422971e897c51bf805f998d75bcfe5d4d858f5002203832875fc91b733/ruff-0.9.0-py3-none-win_amd64.whl", hash = "sha256:0cbc0905d94d21305872f7f8224e30f4bbcd532bc21b2225b2446d8fc7220d19", size = 9689974 },
+    { url = "https://files.pythonhosted.org/packages/73/0e/c00f66731e514be3299801b1d9d54efae0abfe8f00a5c14155f2ab9e2920/ruff-0.9.0-py3-none-win_arm64.whl", hash = "sha256:7b1148771c6ca88f820d761350a053a5794bc58e0867739ea93eb5e41ad978cd", size = 9147729 },
 ]
 
 [[package]]
@@ -806,11 +806,11 @@ wheels = [
 
 [[package]]
 name = "sqlglot"
-version = "26.0.1"
+version = "26.1.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/39/35cee255a3de5a4bfbe8780d200761423bb1949249ff541ba81420eebbf5/sqlglot-26.0.1.tar.gz", hash = "sha256:588cde7739029fda310fb7dd49afdc0a20b79e760e4cd6d5e1cd083e7e458b90", size = 19785413 }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/02/60d542ff60b98ed444176f655a43ecd8c06e9d1f1d38abac3266a41a7eec/sqlglot-26.1.3.tar.gz", hash = "sha256:01fe1a31786e6c7b1ce02470942dfd5fbfd403b7c2d78d9fc4e8aad9eddba2ef", size = 19858552 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/ac/7cf4f8c133cd2cec68937c87322a5052987f3995f21b87e3d545b4d4aa02/sqlglot-26.0.1-py3-none-any.whl", hash = "sha256:ced4967ce3a4a713d35e2037492fbe1a5187936fdfbd72d7b9ace7815c2d2225", size = 437917 },
+    { url = "https://files.pythonhosted.org/packages/71/fe/4521660e276a69f23f7773f52107a1c5ca079cdfaac7c09fb602b60a73c0/sqlglot-26.1.3-py3-none-any.whl", hash = "sha256:e64d696eedb917a0770a10bc0f2a0ce4dffdf95c4fd36cd66e44da3bf2c298c1", size = 439637 },
 ]
 
 [[package]]
@@ -896,14 +896,14 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.28.0"
+version = "20.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/75/53316a5a8050069228a2f6d11f32046cfa94fbb6cc3f08703f59b873de2e/virtualenv-20.28.0.tar.gz", hash = "sha256:2c9c3262bb8e7b87ea801d715fae4495e6032450c71d2309be9550e7364049aa", size = 7650368 }
+sdist = { url = "https://files.pythonhosted.org/packages/50/39/689abee4adc85aad2af8174bb195a819d0be064bf55fcc73b49d2b28ae77/virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329", size = 7650532 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/f9/0919cf6f1432a8c4baa62511f8f8da8225432d22e83e3476f5be1a1edc6e/virtualenv-20.28.0-py3-none-any.whl", hash = "sha256:23eae1b4516ecd610481eda647f3a7c09aea295055337331bb4e6892ecce47b0", size = 4276702 },
+    { url = "https://files.pythonhosted.org/packages/51/8f/dfb257ca6b4e27cb990f1631142361e4712badab8e3ca8dc134d96111515/virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb", size = 4276719 },
 ]


### PR DESCRIPTION
Previously, when excluded nodes were found in the process, it just tacked them on to a hardcoded `dbt build -s state:modified+`.  This is pretty limiting though and doesn't account for the more complex steps that a company may have.

This PR will respect the steps in the specified job and will tack on the exclusions where commands start with `dbt build`, `dbt run`, or `dbt test`.  **The `dbt snapshot` and `dbt seed` commands can also accept the `--exclude` flag but is out of scope for this PR.**